### PR TITLE
chore: Only deploy web version on dispatch or merge with main

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -79,7 +79,7 @@ jobs:
   export_windows:
     name: Windows Export
     runs-on: ubuntu-24.04
-    if: ${{ github.event.inputs.export_platform == 'windows' || github.event.inputs.export_platform == 'all' || github.event_name == 'pull_request' }}
+    if: ${{ github.event.inputs.export_platform == 'windows' || github.event.inputs.export_platform == 'all' || github.event_name == 'pull_request' || github.event_name == 'push' }}
     container:
       image: barichello/godot-ci:4.3
     steps:
@@ -114,7 +114,7 @@ jobs:
   export_linux:
     name: Linux Export
     runs-on: ubuntu-24.04
-    if: ${{ github.event.inputs.export_platform == 'linux' || github.event.inputs.export_platform == 'all' || github.event_name == 'pull_request' }}
+    if: ${{ github.event.inputs.export_platform == 'linux' || github.event.inputs.export_platform == 'all' || github.event_name == 'pull_request' || github.event_name == 'push' }}
     container:
       image: barichello/godot-ci:4.3
     steps:
@@ -149,7 +149,7 @@ jobs:
   export_web:
     name: Web Export
     runs-on: ubuntu-24.04
-    if: ${{ github.event.inputs.export_platform == 'web' || github.event.inputs.export_platform == 'all' || github.event_name == 'pull_request' }}
+    if: ${{ github.event.inputs.export_platform == 'web' || github.event.inputs.export_platform == 'all' || github.event_name == 'pull_request' || github.event_name == 'push' }}
     container:
       image: barichello/godot-ci:4.3
     steps:
@@ -173,6 +173,7 @@ jobs:
         with:
           path: ${{ env.EXPORT_FOLDER }}/builds/web
       - name: Deploy to GitHub Pages
+        if: ${{ github.event.inputs.export_platform == 'web' || github.event.inputs.export_platform == 'all' || github.event_name == 'push' }}
         id: deployment
         uses: actions/deploy-pages@v4
       - name: Zip Folder
@@ -190,7 +191,7 @@ jobs:
   export_mac:
     name: Mac Export
     runs-on: ubuntu-24.04
-    if: ${{ github.event.inputs.export_platform == 'macos' || github.event.inputs.export_platform == 'all' || github.event_name == 'pull_request' }}
+    if: ${{ github.event.inputs.export_platform == 'macos' || github.event.inputs.export_platform == 'all' || github.event_name == 'pull_request' || github.event_name == 'push' }}
     container:
       image: barichello/godot-ci:4.3
     steps:


### PR DESCRIPTION
Updates the workflow so it it doesn't automatically deploy the web version for every change to a PR, but instead when it's merged with main.

Changes in export job conditions:

* [`.github/workflows/export.yml`](diffhunk://#diff-abd067ac9ffcb98dd6b5da7a1bff2138d3a3a9ced0ba8f74886fbbe3d7686540L82-R82): Updated the `if` conditions for the `export_windows` job to include push events.
* [`.github/workflows/export.yml`](diffhunk://#diff-abd067ac9ffcb98dd6b5da7a1bff2138d3a3a9ced0ba8f74886fbbe3d7686540L117-R117): Updated the `if` conditions for the `export_linux` job to include push events.
* [`.github/workflows/export.yml`](diffhunk://#diff-abd067ac9ffcb98dd6b5da7a1bff2138d3a3a9ced0ba8f74886fbbe3d7686540L152-R152): Updated the `if` conditions for the `export_web` job to include push events.
* [`.github/workflows/export.yml`](diffhunk://#diff-abd067ac9ffcb98dd6b5da7a1bff2138d3a3a9ced0ba8f74886fbbe3d7686540R176): Added a condition to the `Deploy to GitHub Pages` step to include push events.
* [`.github/workflows/export.yml`](diffhunk://#diff-abd067ac9ffcb98dd6b5da7a1bff2138d3a3a9ced0ba8f74886fbbe3d7686540L193-R194): Updated the `if` conditions for the `export_mac` job to include push events.